### PR TITLE
[Messenger] Prevent Redis from deleting messages on rejection

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -343,7 +343,9 @@ class Connection
     {
         try {
             $deleted = $this->connection->xack($this->stream, $this->group, [$id]);
-            $deleted = $this->connection->xdel($this->stream, [$id]) && $deleted;
+            if ($this->deleteAfterAck) {
+                $deleted = $this->connection->xdel($this->stream, [$id]) && $deleted;
+            }
         } catch (\RedisException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }


### PR DESCRIPTION
Unless `delete_after_ack` configuration is set to `true`.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #36619
| License       | MIT

> Redis Messenger transport deletes messages when rejecting, causing other consumers / applications to be unable to reach that message.

> This affects primarily cases where Messenger component is used to read/write with other, third party applications.
